### PR TITLE
Add shadow rendering with blend and depth stencil states

### DIFF
--- a/KerberosEngine/KerberosEngine.cpp
+++ b/KerberosEngine/KerberosEngine.cpp
@@ -39,18 +39,30 @@ WndProc(HWND hWnd, unsigned int message, WPARAM wParam, LPARAM lParam) {
     break;
 
   case WM_RBUTTONDOWN:
-    g_bApp.mouseLeftDown = true;
+    g_bApp.mouseRightDown = true;
     break;
 
   case WM_RBUTTONUP:
-    g_bApp.mouseLeftDown = false;
+    g_bApp.mouseRightDown = false;
+    break;
+
+  case WM_MBUTTONDOWN:
+    g_bApp.mouseMiddleDown = true;
+    break;
+
+  case WM_MBUTTONUP:
+    g_bApp.mouseMiddleDown = false;
     break;
 
   case WM_MOUSEMOVE:
-    if (g_bApp.mouseLeftDown) {
+    if (g_bApp.mouseRightDown) {
       int x = LOWORD(lParam);
       int y = HIWORD(lParam);
       g_bApp.RotateCamera(x, y);
+    } else if (g_bApp.mouseMiddleDown) {
+      int x = LOWORD(lParam);
+      int y = HIWORD(lParam);
+      g_bApp.PanCamera(x, y);
     }
     break;
 

--- a/KerberosEngine/KerberosEngine_2010.vcxproj
+++ b/KerberosEngine/KerberosEngine_2010.vcxproj
@@ -433,7 +433,9 @@
     <ClCompile Include="KerberosEngine.cpp" />
     <ClCompile Include="Source\Actor.cpp" />
     <ClCompile Include="Source\BaseApp.cpp" />
+    <ClCompile Include="Source\BlendState.cpp" />
     <ClCompile Include="Source\Buffer.cpp" />
+    <ClCompile Include="Source\DepthStencilState.cpp" />
     <ClCompile Include="Source\DepthStencilView.cpp" />
     <ClCompile Include="Source\Device.cpp" />
     <ClCompile Include="Source\DeviceContext.cpp" />
@@ -462,7 +464,9 @@
     <ClInclude Include="imGui\imgui-docking\imstb_textedit.h" />
     <ClInclude Include="imGui\imgui-docking\imstb_truetype.h" />
     <ClInclude Include="include\BaseApp.h" />
+    <ClInclude Include="include\BlendState.h" />
     <ClInclude Include="include\Buffer.h" />
+    <ClInclude Include="include\DepthStencilState.h" />
     <ClInclude Include="include\DepthStencilView.h" />
     <ClInclude Include="include\Device.h" />
     <ClInclude Include="include\DeviceContext.h" />

--- a/KerberosEngine/Source/Actor.cpp
+++ b/KerberosEngine/Source/Actor.cpp
@@ -58,6 +58,36 @@ Actor::render(DeviceContext& deviceContext) {
 }
 
 void
+Actor::renderShadow(DeviceContext& deviceContext, XMMATRIX shadowMatrix) {
+  m_sampler.render(deviceContext, 0, 1);
+
+  // Update Buffers for each mesh on the actor with shadow settings
+  for (unsigned int i = 0; i < m_meshes.size(); i++) {
+    m_vertexBuffers[i].render(deviceContext, 0, 1);
+    m_indexBuffers[i].render(deviceContext, 0, 1, false, DXGI_FORMAT_R32_UINT);
+
+    if (m_textures.size() > 0) {
+      if (i < m_textures.size()) {
+        m_textures[i].render(deviceContext, 0, 1);
+      }
+    }
+
+    // Update with shadow matrix and color
+    CBChangesEveryFrame shadowCB;
+    shadowCB.mWorld = XMMatrixTranspose(shadowMatrix);
+    shadowCB.vMeshColor = XMFLOAT4(0.0f, 0.0f, 0.0f, 0.5f);
+    shadowCB.isShadow = 0.0f; // Not needed now
+    shadowCB.ShadowMatrix = XMMatrixIdentity();
+
+    m_modelBuffer.update(deviceContext, 0, nullptr, &shadowCB, 0, 0);
+    m_modelBuffer.render(deviceContext, 2, 1, true);
+
+    deviceContext.IASetPrimitiveTopology(D3D11_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
+    deviceContext.DrawIndexed(m_meshes[i].m_numIndex, 0, 0);
+  }
+}
+
+void
 Actor::destroy() {
   for (auto& vertexBuffer : m_vertexBuffers) {
     vertexBuffer.destroy();

--- a/KerberosEngine/Source/BaseApp.cpp
+++ b/KerberosEngine/Source/BaseApp.cpp
@@ -85,7 +85,28 @@ BaseApp::init() {
   XMVECTOR Up = XMVectorSet(0.0f, 1.0f, 0.0f, 0.0f);
   m_View = XMMatrixLookAtLH(Eye, At, Up);
 
+  // Set camera position and orientation
+  m_camera.position = XMFLOAT3(0.0f, 3.0f, -6.0f);
+  m_camera.target = XMFLOAT3(0.0f, 1.0f, 0.0f);
+  m_camera.up = XMFLOAT3(0.0f, 1.0f, 0.0f);
+  XMVECTOR forward = XMVector3Normalize(At - Eye);
+  XMStoreFloat3(&m_camera.forward, forward);
+  XMVECTOR right = XMVector3Cross(forward, Up);
+  XMStoreFloat3(&m_camera.right, XMVector3Normalize(right));
+
   m_UI.init(m_window.m_hWnd, m_device.m_device, m_deviceContext.m_deviceContext);
+
+  // Initialize blend state for shadows
+  hr = m_blendState.init(m_device);
+  if (FAILED(hr)) {
+    return hr;
+  }
+
+  // Initialize depth stencil state for shadows (disable depth test and write)
+  hr = m_shadowDepthStencilState.init(m_device, false, D3D11_DEPTH_WRITE_MASK_ZERO, D3D11_COMPARISON_ALWAYS, false);
+  if (FAILED(hr)) {
+    return hr;
+  }
 
 
   // Set model actor
@@ -221,7 +242,7 @@ BaseApp::init() {
   AMorgana = EngineUtilities::MakeShared<Actor>(m_device);
   if (!AMorgana.isNull()) {
     // Init Transform
-    AMorgana->getComponent<Transform>()->setTransform(EngineUtilities::Vector3(-1.2, -5.9f, 2.5f),
+    AMorgana->getComponent<Transform>()->setTransform(EngineUtilities::Vector3(-1.2, 1.0f, 2.5f),
       EngineUtilities::Vector3(-2.0f, 3.43f, 0.0f),
       EngineUtilities::Vector3(0.1, 0.1, 0.1));
     // Init Actor Mesh
@@ -257,7 +278,7 @@ BaseApp::init() {
   APistol = EngineUtilities::MakeShared<Actor>(m_device);
   if (!APistol.isNull()) {
     // Init Transform
-    APistol->getComponent<Transform>()->setTransform(EngineUtilities::Vector3(-5.0, -1.0f, 0.5f),
+    APistol->getComponent<Transform>()->setTransform(EngineUtilities::Vector3(-5.0, 2.0f, 0.5f),
       EngineUtilities::Vector3(0.0f, 1.3f, 0.0f),
       EngineUtilities::Vector3(4.5f, 4.5f, 4.5f));
     // Init Actor Mesh
@@ -292,7 +313,7 @@ BaseApp::init() {
   ADigimon = EngineUtilities::MakeShared<Actor>(m_device);
   if (!ADigimon.isNull()) {
     // Init Transform
-    ADigimon->getComponent<Transform>()->setTransform(EngineUtilities::Vector3(8.5, -3.5, 2.6),
+    ADigimon->getComponent<Transform>()->setTransform(EngineUtilities::Vector3(8.5, 2.5, 2.6),
       EngineUtilities::Vector3(0.0f, 4.2, 0.0f),
       EngineUtilities::Vector3(2.0f, 2.0f, 2.0f));
     // Init Actor Mesh
@@ -325,7 +346,7 @@ BaseApp::init() {
   ACerb = EngineUtilities::MakeShared<Actor>(m_device);
 
   if (!ACerb.isNull()) {
-    ACerb->getComponent<Transform>()->setTransform(EngineUtilities::Vector3(8.5, -3.5, 2.6),
+    ACerb->getComponent<Transform>()->setTransform(EngineUtilities::Vector3(8.5, 3.5, 2.6),
       EngineUtilities::Vector3(0.0f, 4.2, 0.0f),
       EngineUtilities::Vector3(0.02f, 0.02f, 0.02f));
 
@@ -338,6 +359,40 @@ BaseApp::init() {
   }
   else {
     ERROR("Actor", "ACerb", "Failed to create actor.");
+  }
+
+  // Create Plane
+  MeshComponent planeMesh;
+  planeMesh.m_name = "Plane";
+  planeMesh.m_vertex = {
+    { XMFLOAT3(-20.0f, 0.0f, -20.0f), XMFLOAT2(0.0f, 0.0f) },
+    { XMFLOAT3(20.0f, 0.0f, -20.0f), XMFLOAT2(1.0f, 0.0f) },
+    { XMFLOAT3(20.0f, 0.0f, 20.0f), XMFLOAT2(1.0f, 1.0f) },
+    { XMFLOAT3(-20.0f, 0.0f, 20.0f), XMFLOAT2(0.0f, 1.0f) }
+  };
+  planeMesh.m_index = { 0, 2, 1, 0, 3, 2 };
+  planeMesh.m_numVertex = 4;
+  planeMesh.m_numIndex = 6;
+
+  std::vector<MeshComponent> planeMeshes = { planeMesh };
+
+  Texture planeTexture;
+  planeTexture.init(m_device, "Textures/Default.png", ExtensionType::PNG);
+  m_planeTextures.push_back(planeTexture);
+
+  APlane = EngineUtilities::MakeShared<Actor>(m_device);
+  if (!APlane.isNull()) {
+    APlane->getComponent<Transform>()->setTransform(EngineUtilities::Vector3(0.0f, 0.0f, 0.0f),
+      EngineUtilities::Vector3(0.0f, 0.0f, 0.0f),
+      EngineUtilities::Vector3(1.0f, 1.0f, 1.0f));
+    APlane->setMesh(m_device, planeMeshes);
+    APlane->setTextures(m_planeTextures);
+
+    m_actors.push_back(APlane);
+    MESSAGE("Actor", "APlane", (APlane->getName() + " - Actor accessed successfully.").c_str());
+  }
+  else {
+    ERROR("Actor", "APlane", "Failed to create actor.");
   }
 
   return S_OK;
@@ -385,6 +440,7 @@ BaseApp::update() {
   APistol->update(0, m_deviceContext);
   ADigimon->update(0, m_deviceContext);
   ACerb->update(0, m_deviceContext);
+  APlane->update(0, m_deviceContext);
 }
 
 void
@@ -405,11 +461,43 @@ BaseApp::render() {
   m_shaderProgram.render(m_deviceContext);
 
   // Render the models
+  APlane->render(m_deviceContext);
   AKoro->render(m_deviceContext);
   AMorgana->render(m_deviceContext);
   APistol->render(m_deviceContext);
   ADigimon->render(m_deviceContext);
   ACerb->render(m_deviceContext);
+
+  // Render shadows
+  // Set blend state for shadows
+  m_blendState.render(m_deviceContext);
+  // Set depth stencil state for shadows (disable depth write)
+  m_shadowDepthStencilState.render(m_deviceContext);
+
+  // Light position (adjust as needed)
+  XMFLOAT4 lightPos(0.0f, 10.0f, 0.0f, 1.0f);
+
+  // Render shadows for each actor except the plane
+  std::vector<EngineUtilities::TSharedPointer<Actor>> shadowActors = { AKoro, AMorgana, APistol, ADigimon, ACerb };
+  for (auto& actor : shadowActors) {
+    // Calculate shadow matrix
+    float dot = lightPos.y;
+    XMMATRIX shadowMatrix = XMMATRIX(
+      dot, -lightPos.x, 0.0f, 0.0f,
+      0.0f, 0.0f, 0.0f, 0.0f,
+      0.0f, -lightPos.z, dot, 0.0f,
+      0.0f, -1.0f, 0.0f, dot
+    );
+
+    XMMATRIX worldShadow = actor->getComponent<Transform>()->matrix * shadowMatrix;
+
+    // Render the shadow
+    actor->renderShadow(m_deviceContext, worldShadow);
+  }
+
+  // Reset blend and depth stencil states
+  m_blendState.render(m_deviceContext, nullptr, 0xffffffff, true);
+  m_shadowDepthStencilState.render(m_deviceContext, 0, true);
 
   // Set Constant Buffers and asign Shaders
   m_neverChanges.render(m_deviceContext, 0, 1);
@@ -433,6 +521,10 @@ BaseApp::destroy() {
   APistol->destroy();
   ADigimon->destroy();
   ACerb->destroy();
+  APlane->destroy();
+
+  m_blendState.destroy();
+  m_shadowDepthStencilState.destroy();
 
   m_changeOnResize.destroy();
   m_changesEveryFrame.destroy();
@@ -564,11 +656,11 @@ void
 BaseApp::UpdateCamera() {
   // Convertir la dirección a vectores normalizados
   XMVECTOR pos = XMLoadFloat3(&m_camera.position);
-  XMVECTOR dir = XMLoadFloat3(&m_camera.forward);
+  XMVECTOR target = XMLoadFloat3(&m_camera.target);
   XMVECTOR up = XMLoadFloat3(&m_camera.up);
 
   // Calcular la nueva vista
-  m_View = XMMatrixLookAtLH(pos, pos + dir, up);
+  m_View = XMMatrixLookAtLH(pos, target, up);
 
   // Transponer y actualizar el buffer de la vista
   cbNeverChanges.mView = XMMatrixTranspose(m_View);
@@ -601,6 +693,39 @@ BaseApp::RotateCamera(int mouseX, int mouseY) {
 
   XMStoreFloat3(&m_camera.forward, XMVector3Normalize(forward));
   XMStoreFloat3(&m_camera.right, XMVector3Normalize(right));
+
+  // Update position to orbit around target
+  XMVECTOR target = XMLoadFloat3(&m_camera.target);
+  float distance = XMVectorGetX(XMVector3Length(target - XMLoadFloat3(&m_camera.position)));
+  XMVECTOR newPos = target - forward * distance;
+  XMStoreFloat3(&m_camera.position, newPos);
+}
+
+void 
+BaseApp::PanCamera(int mouseX, int mouseY) {
+  float offsetX = (mouseX - lastX) * panSpeed;
+  float offsetY = (mouseY - lastY) * panSpeed;
+  lastX = mouseX;
+  lastY = mouseY;
+
+  XMVECTOR pos = XMLoadFloat3(&m_camera.position);
+  XMVECTOR target = XMLoadFloat3(&m_camera.target);
+  XMVECTOR right = XMLoadFloat3(&m_camera.right);
+  XMVECTOR up = XMLoadFloat3(&m_camera.up);
+
+  XMVECTOR delta = -right * offsetX + up * offsetY;
+
+  pos += delta;
+  target += delta;
+
+  XMStoreFloat3(&m_camera.position, pos);
+  XMStoreFloat3(&m_camera.target, target);
+
+  // Update forward vector
+  XMVECTOR forward = XMVector3Normalize(target - pos);
+  XMStoreFloat3(&m_camera.forward, forward);
+  XMVECTOR newRight = XMVector3Cross(forward, XMLoadFloat3(&m_camera.up));
+  XMStoreFloat3(&m_camera.right, XMVector3Normalize(newRight));
 }
 
 int

--- a/KerberosEngine/Source/BlendState.cpp
+++ b/KerberosEngine/Source/BlendState.cpp
@@ -1,0 +1,69 @@
+#include "BlendState.h"
+#include "Device.h"
+#include "DeviceContext.h"
+
+HRESULT
+BlendState::init(Device& device) {
+  if (!device.m_device) {
+    ERROR("BlendState", "init", "Device is null.");
+    return E_POINTER;
+  }
+
+  D3D11_BLEND_DESC blendDesc = {};
+  blendDesc.AlphaToCoverageEnable = FALSE;
+  blendDesc.IndependentBlendEnable = FALSE;
+
+  D3D11_RENDER_TARGET_BLEND_DESC rtBlendDesc = {};
+  rtBlendDesc.BlendEnable = TRUE;
+  rtBlendDesc.SrcBlend = D3D11_BLEND_SRC_ALPHA;
+  rtBlendDesc.DestBlend = D3D11_BLEND_INV_SRC_ALPHA;
+  rtBlendDesc.BlendOp = D3D11_BLEND_OP_ADD;
+  rtBlendDesc.SrcBlendAlpha = D3D11_BLEND_ONE;
+  rtBlendDesc.DestBlendAlpha = D3D11_BLEND_ZERO;
+  rtBlendDesc.BlendOpAlpha = D3D11_BLEND_OP_ADD;
+  rtBlendDesc.RenderTargetWriteMask = D3D11_COLOR_WRITE_ENABLE_ALL;
+
+  blendDesc.RenderTarget[0] = rtBlendDesc;
+
+  HRESULT hr = device.m_device->CreateBlendState(&blendDesc, &m_blendState);
+  if (FAILED(hr)) {
+    ERROR("BlendState", "init",
+      ("Failed to create blend state. HRESULT: " + std::to_string(hr)).c_str());
+    return hr;
+  }
+
+  return S_OK;
+}
+
+void
+BlendState::render(DeviceContext& deviceContext,
+                   float* blendFactor,
+                   unsigned int sampleMask,
+                   bool reset) {
+  if (!deviceContext.m_deviceContext) {
+    ERROR("BlendState", "render", "DeviceContext is nullptr.");
+    return;
+  }
+  if (!m_blendState && !reset) {
+    ERROR("BlendState", "render", "BlendState is not initialized.");
+    return;
+  }
+
+  float defaultBlendFactor[4] = { 0.f, 0.f, 0.f, 0.f };
+
+  if (!blendFactor) {
+    blendFactor = defaultBlendFactor;
+  }
+
+  if (!reset) {
+    deviceContext.m_deviceContext->OMSetBlendState(m_blendState, blendFactor, sampleMask);
+  }
+  else {
+    deviceContext.m_deviceContext->OMSetBlendState(nullptr, blendFactor, sampleMask);
+  }
+}
+
+void
+BlendState::destroy() {
+  SAFE_RELEASE(m_blendState);
+}

--- a/KerberosEngine/Source/DepthStencilState.cpp
+++ b/KerberosEngine/Source/DepthStencilState.cpp
@@ -1,0 +1,66 @@
+#include "DepthStencilState.h"
+#include "Device.h"
+#include "DeviceContext.h"
+
+HRESULT
+DepthStencilState::init(Device& device,
+                        bool depthEnable,
+                        D3D11_DEPTH_WRITE_MASK depthWriteMask,
+                        D3D11_COMPARISON_FUNC depthFunc,
+                        bool stencilEnable) {
+  if (!device.m_device) {
+    ERROR("DepthStencilState", "init", "Device is null.");
+    return E_POINTER;
+  }
+
+  D3D11_DEPTH_STENCIL_DESC dsDesc = {};
+  dsDesc.DepthEnable = depthEnable;
+  dsDesc.DepthWriteMask = depthWriteMask;
+  dsDesc.DepthFunc = depthFunc;
+  dsDesc.StencilEnable = stencilEnable;
+  if (stencilEnable) {
+    // Default stencil settings if enabled
+    dsDesc.StencilReadMask = D3D11_DEFAULT_STENCIL_READ_MASK;
+    dsDesc.StencilWriteMask = D3D11_DEFAULT_STENCIL_WRITE_MASK;
+    dsDesc.FrontFace.StencilFailOp = D3D11_STENCIL_OP_KEEP;
+    dsDesc.FrontFace.StencilDepthFailOp = D3D11_STENCIL_OP_KEEP;
+    dsDesc.FrontFace.StencilPassOp = D3D11_STENCIL_OP_KEEP;
+    dsDesc.FrontFace.StencilFunc = D3D11_COMPARISON_ALWAYS;
+    dsDesc.BackFace = dsDesc.FrontFace;
+  }
+
+  HRESULT hr = device.m_device->CreateDepthStencilState(&dsDesc, &m_depthStencilState);
+  if (FAILED(hr)) {
+    ERROR("DepthStencilState", "init",
+      ("Failed to create depth stencil state. HRESULT: " + std::to_string(hr)).c_str());
+    return hr;
+  }
+
+  return S_OK;
+}
+
+void
+DepthStencilState::render(DeviceContext& deviceContext,
+                          unsigned int stencilRef,
+                          bool reset) {
+  if (!deviceContext.m_deviceContext) {
+    ERROR("DepthStencilState", "render", "DeviceContext is nullptr.");
+    return;
+  }
+  if (!m_depthStencilState && !reset) {
+    ERROR("DepthStencilState", "render", "DepthStencilState is not initialized.");
+    return;
+  }
+
+  if (!reset) {
+    deviceContext.m_deviceContext->OMSetDepthStencilState(m_depthStencilState, stencilRef);
+  }
+  else {
+    deviceContext.m_deviceContext->OMSetDepthStencilState(nullptr, stencilRef);
+  }
+}
+
+void
+DepthStencilState::destroy() {
+  SAFE_RELEASE(m_depthStencilState);
+}

--- a/KerberosEngine/include/BaseApp.h
+++ b/KerberosEngine/include/BaseApp.h
@@ -15,6 +15,8 @@
 #include "UserInterface.h"
 #include "ModelLoader.h"
 #include "ECS/Actor.h"
+#include "BlendState.h"
+#include "DepthStencilState.h"
 
 class
   BaseApp {
@@ -80,6 +82,14 @@ public:
   RotateCamera(int mouseX, int mouseY);
 
   /**
+  * @brief Pans the camera based on mouse movement.
+  * @param mouseX The current X position of the mouse.
+  * @param mouseY The current Y position of the mouse.
+  */
+  void
+  PanCamera(int mouseX, int mouseY);
+
+  /**
    * @brief Runs the application from the main entry point.
    * @param hInstance Handle to the instance of the program.
    * @param hPrevInstance Handle to the previous instance.
@@ -109,6 +119,8 @@ private:
   Buffer                              m_changeOnResize;
   Buffer                              m_changesEveryFrame;
   UserInterface                       m_UI;
+  BlendState                          m_blendState;
+  DepthStencilState                   m_shadowDepthStencilState;
 
   Texture m_default;
   ModelLoader                         m_mloader;
@@ -131,6 +143,9 @@ private:
   EngineUtilities::TSharedPointer<Actor> ACerb;
   std::vector<Texture>                m_cerbTextures;
 
+  EngineUtilities::TSharedPointer<Actor> APlane;
+  std::vector<Texture>                m_planeTextures;
+
   XMMATRIX                            m_View;
   XMMATRIX                            m_Projection;
 
@@ -145,5 +160,7 @@ public:
   int lastX;
   int lastY;
   float sensitivity = 0.01f;
-  bool mouseLeftDown = false;
+  float panSpeed = 0.01f;
+  bool mouseRightDown = false;
+  bool mouseMiddleDown = false;
 };

--- a/KerberosEngine/include/BlendState.h
+++ b/KerberosEngine/include/BlendState.h
@@ -1,0 +1,41 @@
+#pragma once
+#include "Prerequisites.h"
+
+// Forward Declarations
+class Device;
+class DeviceContext;
+
+class BlendState {
+public:
+  /**
+   * @brief Default constructor and destructor.
+   */
+  BlendState() = default;
+  ~BlendState() = default;
+
+  /**
+   * @brief Initializes the blend state for alpha blending.
+   * @param device Reference to the device.
+   */
+  HRESULT init(Device& device);
+
+  /**
+   * @brief Sets the blend state for rendering.
+   * @param deviceContext Reference to the device context.
+   * @param blendFactor Blend factors.
+   * @param sampleMask Sample mask.
+   * @param reset If true, resets the blend state.
+   */
+  void render(DeviceContext& deviceContext,
+              float* blendFactor = nullptr,
+              unsigned int sampleMask = 0xffffffff,
+              bool reset = false);
+
+  /**
+   * @brief Releases the blend state resources.
+   */
+  void destroy();
+
+private:
+  ID3D11BlendState* m_blendState = nullptr;
+};

--- a/KerberosEngine/include/DepthStencilState.h
+++ b/KerberosEngine/include/DepthStencilState.h
@@ -1,0 +1,47 @@
+#pragma once
+#include "Prerequisites.h"
+
+// Forward Declarations
+class Device;
+class DeviceContext;
+
+class DepthStencilState {
+public:
+  /**
+   * @brief Default constructor and destructor.
+   */
+  DepthStencilState() = default;
+  ~DepthStencilState() = default;
+
+  /**
+   * @brief Initializes the depth stencil state.
+   * @param device Reference to the device.
+   * @param depthEnable Enable depth testing.
+   * @param depthWriteMask Depth write mask.
+   * @param depthFunc Depth comparison function.
+   * @param stencilEnable Enable stencil testing.
+   */
+  HRESULT init(Device& device,
+               bool depthEnable = true,
+               D3D11_DEPTH_WRITE_MASK depthWriteMask = D3D11_DEPTH_WRITE_MASK_ALL,
+               D3D11_COMPARISON_FUNC depthFunc = D3D11_COMPARISON_LESS,
+               bool stencilEnable = false);
+
+  /**
+   * @brief Sets the depth stencil state for rendering.
+   * @param deviceContext Reference to the device context.
+   * @param stencilRef Stencil reference value.
+   * @param reset If true, resets the depth stencil state.
+   */
+  void render(DeviceContext& deviceContext,
+              unsigned int stencilRef = 0,
+              bool reset = false);
+
+  /**
+   * @brief Releases the depth stencil state resources.
+   */
+  void destroy();
+
+private:
+  ID3D11DepthStencilState* m_depthStencilState = nullptr;
+};

--- a/KerberosEngine/include/ECS/Actor.h
+++ b/KerberosEngine/include/ECS/Actor.h
@@ -44,6 +44,14 @@ public:
   render(DeviceContext& deviceContext) override;
 
   /**
+   * @brief Renders the actor with shadow settings.
+   * @param deviceContext Reference to the device context used for rendering.
+   * @param shadowMatrix The shadow transformation matrix.
+   */
+  void
+  renderShadow(DeviceContext& deviceContext, XMMATRIX shadowMatrix);
+
+  /**
    * @brief Destroys the actor and releases associated resources.
    */
   void

--- a/KerberosEngine/include/Prerequisites.h
+++ b/KerberosEngine/include/Prerequisites.h
@@ -12,14 +12,14 @@
 // #include memory
 #include <thread>
 
-// Librerias DirectX
+// DirectX Libraries
 #include <d3d11.h>
 #include <d3dx11.h>
 #include <d3dcompiler.h>
 #include "resource.h"
 #include "Resource.h"
 
-// Librerías de ImGUI
+// ImGUI Lirbaries
 #include <imgui.h>
 #include <imgui_impl_dx11.h>
 #include <imgui_internal.h>
@@ -70,6 +70,8 @@ struct
   CBChangesEveryFrame {
   XMMATRIX mWorld;
   XMFLOAT4 vMeshColor;
+  float isShadow;
+  XMMATRIX ShadowMatrix;
 };
 
 enum
@@ -88,7 +90,7 @@ enum
 enum
   ComponentType {
   NONE = 0,     ///< Tipo de componente no especificado.
-  TRANSFORM = 1,///< Componente de transformación.
+  TRANSFORM = 1,///< Componente de transformaciï¿½n.
   MESH = 2,     ///< Componente de malla.
   MATERIAL = 3,  ///< Componente de material.
   PHYSICS = 4,
@@ -103,11 +105,11 @@ struct
   XMFLOAT3 target;  // Punto al que mira
 
   XMFLOAT3 up;      // Vector hacia arriba
-  XMFLOAT3 forward; // Dirección adelante
-  XMFLOAT3 right;   // Direción a la derecha
+  XMFLOAT3 forward; // Direccion adelante
+  XMFLOAT3 right;   // Direcion a la derecha
 
-  float yaw;        // Rotación en el eje Y
-  float pitch;      // Rotación en el eje X
+  float yaw;        // Rotacion en el eje Y
+  float pitch;      // Rotacion en el eje X
 
   Camera() {
     position = XMFLOAT3(0.0f, 1.0f, -5.0f);


### PR DESCRIPTION
Introduces BlendState and DepthStencilState classes to support shadow rendering with alpha blending and custom depth settings. Adds a renderShadow method to Actor, updates BaseApp to render planar shadows for all actors except the plane, and implements camera panning with middle mouse button. Also includes a procedural plane mesh for shadow projection and updates project files accordingly.